### PR TITLE
Added trackingAccount field to SwapRequest interface

### DIFF
--- a/generated/models/SwapRequest.ts
+++ b/generated/models/SwapRequest.ts
@@ -69,6 +69,12 @@ export interface SwapRequest {
      */
     feeAccount?: string;
     /**
+     * Tracking account public key. Specify any public key to track transactions. Useful for integrators to associate all swap transactions with this account for analytical purposes.
+     * @type {string}
+     * @memberof SwapRequest
+     */
+    trackingAccount?: string;
+    /**
      * 
      * @type {SwapRequestComputeUnitPriceMicroLamports}
      * @memberof SwapRequest


### PR DESCRIPTION
Added trackingAccount field to the SwapRequest Interface.

The Jupiter APIs already support this field, it was just missing from the contact.