### PR TITLE
chore: add prepublishOnly hook so dist/ is always built before publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "dev-swap": "FLOW=quoteAndSwap ts-node ./example/index.ts",
     "dev-quote": "FLOW=quote ts-node ./example/index.ts",
     "test": "vitest",
-    "build": "npm run openapi-gen && tsup src/index.ts --dts --format esm,cjs",
+    "build": "npm run openapi-gen && npm run bundle",
+    "bundle": "tsup src/index.ts --dts --format esm,cjs",
+    "prepublishOnly": "npm run bundle",
     "openapi-gen": "openapi-generator-cli generate -i swagger.yaml -o generated -g typescript-fetch --skip-validate-spec --additional-properties=supportsES6=true,typescriptThreePlus=true",
     "openapi-gen-rust": "openapi-generator-cli generate -i swagger.yaml -o generated -g rust"
   },


### PR DESCRIPTION
## Problem
The published package is entirely `dist/` — `main`, `module`, and `typings` all resolve there and `files` is `["dist"]`. But `dist/` is gitignored and only produced by a manual `npm run build` (a step in `PUBLISH.md`). Nothing enforces that build, so a publish from a clean checkout / one where the build step is skipped / ships a package with no code

## Change
    "build": "npm run openapi-gen && npm run bundle",
    "bundle": "tsup src/index.ts --dts --format esm,cjs",
    "prepublishOnly": "npm run bundle",

`prepublishOnly` runs automatically before `npm publish`/`pnpm publish`, so `dist/` is always built and packed

## Design notes
- **`prepublishOnly`, not `prepare`** — `prepare` also runs on every `npm install`, pushing the build toolchain onto consumers/contributors; `prepublishOnly` runs only at publish time
- **The hook runs `bundle` (tsup), not the full `build`** — `generated/` is committed, so `dist/` builds without invoking `openapi-gen` (which needs Java) and without regenerating tracked sources at publish time. `bundle` is factored out of `build` so the tsup command isn't duplicated
- No change for consumers or `npm install`; `build` behaves exactly as before